### PR TITLE
Self referential modules for libraries and the kernel

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -977,6 +977,8 @@ fn resolveLibrary(
             .source_file = file_source,
         });
 
+        try module.dependencies.put(description.name, module);
+
         for (library_dependencies) |library| {
             try module.dependencies.put(library.name, library.module);
         }

--- a/kernel/arch/aarch64/Uart.zig
+++ b/kernel/arch/aarch64/Uart.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../../kernel.zig");
+const kernel = @import("kernel");
 const aarch64 = @import("aarch64.zig");
 
 const Uart = @This();

--- a/kernel/arch/aarch64/aarch64.zig
+++ b/kernel/arch/aarch64/aarch64.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../../kernel.zig");
+const kernel = @import("kernel");
 
 comptime {
     // make sure the entry points are referenced

--- a/kernel/arch/aarch64/instructions.zig
+++ b/kernel/arch/aarch64/instructions.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../../kernel.zig");
+const kernel = @import("kernel");
 const aarch64 = @import("aarch64.zig");
 
 /// Disable interrupts and put the CPU to sleep.

--- a/kernel/arch/aarch64/setup.zig
+++ b/kernel/arch/aarch64/setup.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../../kernel.zig");
+const kernel = @import("kernel");
 const aarch64 = @import("aarch64.zig");
 
 const limine = kernel.spec.limine;

--- a/kernel/arch/arch.zig
+++ b/kernel/arch/arch.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../kernel.zig");
+const kernel = @import("kernel");
 
 pub const aarch64 = @import("aarch64/aarch64.zig");
 pub const x86_64 = @import("x86_64/x86_64.zig");

--- a/kernel/arch/arch_helpers.zig
+++ b/kernel/arch/arch_helpers.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../kernel.zig");
+const kernel = @import("kernel");
 
 const arch = @import("arch.zig");
 

--- a/kernel/arch/x86_64/Gdt.zig
+++ b/kernel/arch/x86_64/Gdt.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../../kernel.zig");
+const kernel = @import("kernel");
 const x86_64 = @import("x86_64.zig");
 
 pub const Gdt = extern struct {

--- a/kernel/arch/x86_64/Tss.zig
+++ b/kernel/arch/x86_64/Tss.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../../kernel.zig");
+const kernel = @import("kernel");
 const x86_64 = @import("x86_64.zig");
 
 pub const Tss = extern struct {

--- a/kernel/arch/x86_64/serial.zig
+++ b/kernel/arch/x86_64/serial.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../../kernel.zig");
+const kernel = @import("kernel");
 const x86_64 = @import("x86_64.zig");
 
 const portReadU8 = x86_64.instructions.portReadU8;

--- a/kernel/arch/x86_64/setup.zig
+++ b/kernel/arch/x86_64/setup.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../../kernel.zig");
+const kernel = @import("kernel");
 const x86_64 = @import("x86_64.zig");
 
 const limine = kernel.spec.limine;
@@ -34,6 +34,4 @@ pub fn earlyArchInitialization() void {
 
     log.info("loading tss", .{});
     gdt.setTss(&tss);
-
-    // - implement library system
 }

--- a/kernel/arch/x86_64/x86_64.zig
+++ b/kernel/arch/x86_64/x86_64.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("../../kernel.zig");
+const kernel = @import("kernel");
 
 comptime {
     // make sure the entry points are referenced

--- a/kernel/kernel.zig
+++ b/kernel/kernel.zig
@@ -15,16 +15,6 @@ comptime {
     _ = arch;
 }
 
-pub const std_options = struct {
-    // ensure using `std.log` in the kernel is a compile error
-    pub const log_level = @compileError("use `kernel.log` for logging in the kernel");
-
-    // ensure using `std.log` in the kernel is a compile error
-    pub const logFn = @compileError("use `kernel.log` for logging in the kernel");
-};
-
-pub const panic = panic_implementation.panic;
-
 pub const panic_implementation = struct {
     pub const PanicState = enum(u8) {
         no_op = 0,

--- a/kernel/log.zig
+++ b/kernel/log.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("kernel.zig");
+const kernel = @import("kernel");
 
 var initialized: bool = false;
 

--- a/kernel/root.zig
+++ b/kernel/root.zig
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+//! This file acts as the root file of the kernel executable, with `kernel.zig` being a module.
+//! This allows files in the kernel module to `@import("kernel")` without hitting "file exists in multiple modules" errors
+
+const std = @import("std");
+
+const kernel = @import("kernel");
+
+comptime {
+    _ = kernel;
+}
+
+pub const std_options = struct {
+    // ensure using `std.log` in the kernel is a compile error
+    pub const log_level = @compileError("use `kernel.log` for logging in the kernel");
+
+    // ensure using `std.log` in the kernel is a compile error
+    pub const logFn = @compileError("use `kernel.log` for logging in the kernel");
+};
+
+pub const panic = kernel.panic_implementation.panic;

--- a/kernel/setup.zig
+++ b/kernel/setup.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 const core = @import("core");
-const kernel = @import("kernel.zig");
+const kernel = @import("kernel");
 
 const log = kernel.log.scoped(.setup);
 


### PR DESCRIPTION
This allows arbitrarily nested code to refer to the root of the containing library/kernel with a simple `@import("LIBRARY/APPLICATION NAME")`